### PR TITLE
Viz addition + bugfixes

### DIFF
--- a/App/app.py
+++ b/App/app.py
@@ -54,6 +54,7 @@ app.layout = dbc.Container(
         dcc.Store(id="screening-fullresults-store"),
         dcc.Store(id="m2m-subfolders-store"),
         dcc.Store(id="motif-rankings-state", data=None, storage_type="memory"),
+        dcc.Store(id="s2v-download-complete", data=False),
 
     ],
     fluid=False,

--- a/App/callbacks.py
+++ b/App/callbacks.py
@@ -21,15 +21,16 @@ from rdkit import Chem
 from rdkit.Chem.Draw import MolsToGridImage
 
 import MS2LDA
+from App.app_instance import app
 from MS2LDA.Add_On.MassQL.MassQL4MotifDB import load_motifDB, motifDB2motifs
 from MS2LDA.Add_On.Spec2Vec.annotation import calc_embeddings
 from MS2LDA.Add_On.Spec2Vec.annotation_refined import calc_similarity
+from MS2LDA.Mass2Motif import Mass2Motif
 from MS2LDA.Preprocessing.load_and_clean import clean_spectra
 from MS2LDA.Visualisation.ldadict import generate_corpusjson_from_tomotopy
 from MS2LDA.run import filetype_check
 from MS2LDA.run import load_s2v_model
-from MS2LDA.Mass2Motif import Mass2Motif
-from App.app_instance import app
+from MS2LDA.utils import download_model_and_data
 
 # Hardcode the path for .m2m references
 MOTIFDB_FOLDER = "../MS2LDA/MotifDB"
@@ -1783,3 +1784,23 @@ def on_motif_click(ranking_active_cell, screening_active_cell, ranking_data, scr
 
     else:
         raise dash.exceptions.PreventUpdate
+
+
+@app.callback(
+    Output("s2v-download-complete", "data"),
+    Output("run-button", "disabled"),
+    Input("download-s2v-button", "n_clicks"),
+    prevent_initial_call=True,
+)
+def unlock_run_after_download(n_clicks):
+    if not n_clicks:
+        raise dash.exceptions.PreventUpdate
+
+    try:
+        download_model_and_data()  # uses default file_urls from the function
+        return "Spec2Vec model + data download complete."
+    except Exception as e:
+        return f"Download failed: {str(e)}"
+
+    return True, False
+

--- a/App/callbacks.py
+++ b/App/callbacks.py
@@ -1787,20 +1787,16 @@ def on_motif_click(ranking_active_cell, screening_active_cell, ranking_data, scr
 
 
 @app.callback(
+    Output("download-s2v-status", "children"),
     Output("s2v-download-complete", "data"),
-    Output("run-button", "disabled"),
     Input("download-s2v-button", "n_clicks"),
     prevent_initial_call=True,
 )
 def unlock_run_after_download(n_clicks):
     if not n_clicks:
         raise dash.exceptions.PreventUpdate
-
     try:
-        download_model_and_data()  # uses default file_urls from the function
-        return "Spec2Vec model + data download complete."
+        msg = download_model_and_data()
+        return (msg, "Spec2Vec model + data download complete.")
     except Exception as e:
-        return f"Download failed: {str(e)}"
-
-    return True, False
-
+        return f"Download failed: {str(e)}", ""

--- a/App/layout.py
+++ b/App/layout.py
@@ -202,7 +202,7 @@ def create_run_analysis_tab():
                                     dbc.Input(
                                         id="s2v-model-path",
                                         type="text",
-                                        value="../MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_Spec2Vec_pos_CleanedLibraries.model",
+                                        value="../MS2LDA/MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_Spec2Vec_pos_CleanedLibraries.model",
                                     ),
                                 ],
                                 className="mb-3",
@@ -219,7 +219,7 @@ def create_run_analysis_tab():
                                     dbc.Input(
                                         id="s2v-library-embeddings",
                                         type="text",
-                                        value="../MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_CleanedLibraries_Spec2Vec_pos_embeddings.npy",
+                                        value="../MS2LDA/MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_CleanedLibraries_Spec2Vec_pos_embeddings.npy",
                                     ),
                                 ],
                                 className="mb-3",
@@ -231,7 +231,7 @@ def create_run_analysis_tab():
                                     dbc.Input(
                                         id="s2v-library-db",
                                         type="text",
-                                        value="../MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_CombLibraries_spectra.db",
+                                        value="../MS2LDA/MS2LDA/Add_On/Spec2Vec/model_positive_mode/150225_CombLibraries_spectra.db",
                                     ),
                                 ],
                                 className="mb-3",

--- a/App/layout.py
+++ b/App/layout.py
@@ -23,6 +23,28 @@ def create_run_analysis_tab():
             dbc.Row(
                 [
                     dbc.Col(
+                        dcc.Loading(
+                            id="download-s2v-spinner",
+                            type="circle",
+                            children=[
+                                dbc.Button(
+                                    "Download Spec2Vec Files",
+                                    id="download-s2v-button",
+                                    color="info",
+                                    className="mt-3"
+                                ),
+                                html.Div(id="download-s2v-status", style={"marginTop": "10px"})
+                            ]
+                        ),
+                        width=4,
+                    )
+                ],
+                justify="start",
+                className="g-3",
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(
                         [
                             dcc.Upload(
                                 id="upload-data",
@@ -790,6 +812,7 @@ def create_run_analysis_tab():
                                         "Run Analysis",
                                         id="run-button",
                                         color="primary",
+                                        disabled=True
                                     ),
                                 ],
                                 className="d-grid gap-2",

--- a/App/layout.py
+++ b/App/layout.py
@@ -7,44 +7,31 @@ def create_run_analysis_tab():
     tab = html.Div(
         id="run-analysis-tab-content",
         children=[
-            html.Div(
+            # Card 1: Intro / Explanation
+            dbc.Card(
                 [
-                    dcc.Markdown(
-                        """
-                        This tab allows you to run an MS2LDA analysis from scratch using a single uploaded data file. 
-                        You can control basic parameters like the number of motifs, polarity, and top N Spec2Vec matches, 
-                        as well as advanced settings (e.g., min_mz, max_mz). 
-                        When ready, click "Run Analysis" to generate the results and proceed to the other tabs for visualization.
-                        """
-                    )
+                    dbc.CardHeader("MS2LDA Run Analysis Overview"),
+                    dbc.CardBody(
+                        [
+                            dcc.Markdown(
+                                """
+                                This tab allows you to run an MS2LDA analysis from scratch using a single uploaded data file. 
+                                You can control basic parameters like the number of motifs, polarity, and top N Spec2Vec matches, 
+                                as well as advanced settings (e.g., min_mz, max_mz). 
+                                When ready, click "Run Analysis" to generate the results and proceed to the other tabs for visualization.
+                                """
+                            ),
+                        ]
+                    ),
                 ],
-                style={"margin-top": "20px", "margin-bottom": "20px"},
+                style={"border": "1px solid #ccc", "padding": "10px", "marginTop": "20px", "marginBottom": "20px"},
             ),
-            dbc.Row(
+
+            # Card 2: Data upload & basic MS2LDA parameters
+            dbc.Card(
                 [
-                    dbc.Col(
-                        dcc.Loading(
-                            id="download-s2v-spinner",
-                            type="circle",
-                            children=[
-                                dbc.Button(
-                                    "Download Spec2Vec Files",
-                                    id="download-s2v-button",
-                                    color="info",
-                                    className="mt-3"
-                                ),
-                                html.Div(id="download-s2v-status", style={"marginTop": "10px"})
-                            ]
-                        ),
-                        width=4,
-                    )
-                ],
-                justify="start",
-                className="g-3",
-            ),
-            dbc.Row(
-                [
-                    dbc.Col(
+                    dbc.CardHeader("Data Upload & Basic MS2LDA Parameters"),
+                    dbc.CardBody(
                         [
                             dcc.Upload(
                                 id="upload-data",
@@ -85,7 +72,6 @@ def create_run_analysis_tab():
                                 target="n-motifs-tooltip",
                                 placement="right",
                             ),
-
                             html.Div(
                                 [
                                     dbc.Label("Acquisition Type", id="acq-type-tooltip"),
@@ -107,7 +93,6 @@ def create_run_analysis_tab():
                                 target="acq-type-tooltip",
                                 placement="right",
                             ),
-
                             dbc.InputGroup(
                                 [
                                     dbc.InputGroupText("Top N Matches", id="topn-tooltip"),
@@ -123,7 +108,6 @@ def create_run_analysis_tab():
                                 target="topn-tooltip",
                                 placement="right",
                             ),
-
                             html.Div(
                                 [
                                     dbc.Label("Unique Molecules", id="uniqmols-tooltip"),
@@ -145,7 +129,6 @@ def create_run_analysis_tab():
                                 target="uniqmols-tooltip",
                                 placement="right",
                             ),
-
                             html.Div(
                                 [
                                     dbc.Label("Polarity", id="polarity-tooltip"),
@@ -180,6 +163,39 @@ def create_run_analysis_tab():
                                 target="iterations-tooltip",
                                 placement="right",
                             ),
+                        ]
+                    ),
+                ],
+                style={"border": "1px solid #ccc", "padding": "10px", "marginBottom": "20px"},
+            ),
+
+            # Card 3: Spec2Vec Setup
+            dbc.Card(
+                [
+                    dbc.CardHeader("Spec2Vec Setup"),
+                    dbc.CardBody(
+                        [
+                            dcc.Markdown(
+                                """
+                                **Spec2Vec** is used to annotate motifs by comparing them against a pretrained model 
+                                and library embeddings. You can download the necessary files here if you haven't already. 
+                                If the files already exist, the process will skip them.
+                                """
+                            ),
+                            dcc.Loading(
+                                id="download-s2v-spinner",
+                                type="circle",
+                                children=[
+                                    dbc.Button(
+                                        "Download Spec2Vec Files",
+                                        id="download-s2v-button",
+                                        color="info",
+                                        className="mt-3"
+                                    ),
+                                    html.Div(id="download-s2v-status", style={"marginTop": "10px"})
+                                ]
+                            ),
+                            html.Br(),
                             dbc.InputGroup(
                                 [
                                     dbc.InputGroupText("S2V Model Path", id="s2v-model-tooltip"),
@@ -226,6 +242,26 @@ def create_run_analysis_tab():
                                 target="s2v-library-tooltip",
                                 placement="right",
                             ),
+                        ]
+                    ),
+                ],
+                style={"border": "1px solid #ccc", "padding": "10px", "marginBottom": "20px"},
+            ),
+
+            # Card 4: Advanced Settings
+            dbc.Card(
+                [
+                    dbc.CardHeader("Advanced Settings"),
+                    dbc.CardBody(
+                        [
+                            dcc.Markdown(
+                                """
+                                These parameters allow fine-grained control over MS2LDA preprocessing, 
+                                convergence criteria, and model hyperparameters. Generally, 
+                                you can leave them as defaults unless you want to experiment 
+                                with more specialized behaviors or custom thresholding.
+                                """
+                            ),
                             dbc.Button(
                                 "Show/Hide Advanced Settings",
                                 id="advanced-settings-button",
@@ -241,7 +277,6 @@ def create_run_analysis_tab():
                                         [
                                             dbc.Col(
                                                 [
-                                                    # Preprocessing
                                                     html.H6("Preprocessing"),
                                                     dbc.InputGroup(
                                                         [
@@ -279,8 +314,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("max_frags",
-                                                                               id="prep-maxfrags-tooltip"),
+                                                            dbc.InputGroupText("max_frags", id="prep-maxfrags-tooltip"),
                                                             dbc.Input(
                                                                 id="prep-max-frags",
                                                                 type="number",
@@ -297,8 +331,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("min_frags",
-                                                                               id="prep-minfrags-tooltip"),
+                                                            dbc.InputGroupText("min_frags", id="prep-minfrags-tooltip"),
                                                             dbc.Input(
                                                                 id="prep-min-frags",
                                                                 type="number",
@@ -315,8 +348,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("min_intensity",
-                                                                               id="prep-minint-tooltip"),
+                                                            dbc.InputGroupText("min_intensity", id="prep-minint-tooltip"),
                                                             dbc.Input(
                                                                 id="prep-min-intensity",
                                                                 type="number",
@@ -334,8 +366,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("max_intensity",
-                                                                               id="prep-maxint-tooltip"),
+                                                            dbc.InputGroupText("max_intensity", id="prep-maxint-tooltip"),
                                                             dbc.Input(
                                                                 id="prep-max-intensity",
                                                                 type="number",
@@ -356,12 +387,10 @@ def create_run_analysis_tab():
                                             ),
                                             dbc.Col(
                                                 [
-                                                    # Convergence
                                                     html.H6("Convergence"),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("step_size",
-                                                                               id="conv-stepsz-tooltip"),
+                                                            dbc.InputGroupText("step_size", id="conv-stepsz-tooltip"),
                                                             dbc.Input(
                                                                 id="conv-step-size",
                                                                 type="number",
@@ -378,8 +407,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("window_size",
-                                                                               id="conv-winsz-tooltip"),
+                                                            dbc.InputGroupText("window_size", id="conv-winsz-tooltip"),
                                                             dbc.Input(
                                                                 id="conv-window-size",
                                                                 type="number",
@@ -396,8 +424,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("threshold",
-                                                                               id="conv-thresh-tooltip"),
+                                                            dbc.InputGroupText("threshold", id="conv-thresh-tooltip"),
                                                             dbc.Input(
                                                                 id="conv-threshold",
                                                                 type="number",
@@ -419,14 +446,10 @@ def create_run_analysis_tab():
                                                             dbc.Select(
                                                                 id="conv-type",
                                                                 options=[
-                                                                    {"label": "perplexity_history",
-                                                                     "value": "perplexity_history"},
-                                                                    {"label": "entropy_history_doc",
-                                                                     "value": "entropy_history_doc"},
-                                                                    {"label": "entropy_history_topic",
-                                                                     "value": "entropy_history_topic"},
-                                                                    {"label": "log_likelihood_history",
-                                                                     "value": "log_likelihood_history"},
+                                                                    {"label": "perplexity_history", "value": "perplexity_history"},
+                                                                    {"label": "entropy_history_doc", "value": "entropy_history_doc"},
+                                                                    {"label": "entropy_history_topic", "value": "entropy_history_topic"},
+                                                                    {"label": "log_likelihood_history", "value": "log_likelihood_history"},
                                                                 ],
                                                                 value="perplexity_history",
                                                             ),
@@ -452,8 +475,7 @@ def create_run_analysis_tab():
                                                     html.H6("Annotation"),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("criterium",
-                                                                               id="ann-criterium-tooltip"),
+                                                            dbc.InputGroupText("criterium", id="ann-criterium-tooltip"),
                                                             dbc.Select(
                                                                 id="ann-criterium",
                                                                 options=[
@@ -473,8 +495,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("cosine_similarity",
-                                                                               id="ann-cossim-tooltip"),
+                                                            dbc.InputGroupText("cosine_similarity", id="ann-cossim-tooltip"),
                                                             dbc.Input(
                                                                 id="ann-cosine-sim",
                                                                 type="number",
@@ -617,8 +638,7 @@ def create_run_analysis_tab():
                                                     html.H6("Train"),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("parallel",
-                                                                               id="train-parallel-tooltip"),
+                                                            dbc.InputGroupText("parallel", id="train-parallel-tooltip"),
                                                             dbc.Input(
                                                                 id="train-parallel",
                                                                 type="number",
@@ -635,8 +655,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("workers",
-                                                                               id="train-workers-tooltip"),
+                                                            dbc.InputGroupText("workers", id="train-workers-tooltip"),
                                                             dbc.Input(
                                                                 id="train-workers",
                                                                 type="number",
@@ -664,8 +683,7 @@ def create_run_analysis_tab():
                                                     html.H6("Dataset"),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("sig_digits",
-                                                                               id="prep-sigdig-tooltip"),
+                                                            dbc.InputGroupText("sig_digits", id="prep-sigdig-tooltip"),
                                                             dbc.Input(
                                                                 id="prep-sigdig",
                                                                 type="number",
@@ -682,8 +700,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("charge",
-                                                                               id="dataset-charge-tooltip"),
+                                                            dbc.InputGroupText("charge", id="dataset-charge-tooltip"),
                                                             dbc.Input(
                                                                 id="dataset-charge",
                                                                 type="number",
@@ -700,8 +717,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("Run Name",
-                                                                               id="dataset-name-tooltip"),
+                                                            dbc.InputGroupText("Run Name", id="dataset-name-tooltip"),
                                                             dbc.Input(
                                                                 id="dataset-name",
                                                                 type="text",
@@ -718,8 +734,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("Output Folder",
-                                                                               id="dataset-outdir-tooltip"),
+                                                            dbc.InputGroupText("Output Folder", id="dataset-outdir-tooltip"),
                                                             dbc.Input(
                                                                 id="dataset-output-folder",
                                                                 type="text",
@@ -764,8 +779,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("fp threshold",
-                                                                               id="fp-threshold-tooltip"),
+                                                            dbc.InputGroupText("fp threshold", id="fp-threshold-tooltip"),
                                                             dbc.Input(
                                                                 id="fp-threshold",
                                                                 type="number",
@@ -783,8 +797,7 @@ def create_run_analysis_tab():
                                                     ),
                                                     dbc.InputGroup(
                                                         [
-                                                            dbc.InputGroupText("Motif Parameter",
-                                                                               id="motif-param-tooltip"),
+                                                            dbc.InputGroupText("Motif Parameter", id="motif-param-tooltip"),
                                                             dbc.Input(
                                                                 id="motif-parameter",
                                                                 type="number",
@@ -804,26 +817,38 @@ def create_run_analysis_tab():
                                             ),
                                         ]
                                     ),
-                                ],
+                                ]
                             ),
-                            html.Div(
-                                [
-                                    dbc.Button(
-                                        "Run Analysis",
-                                        id="run-button",
-                                        color="primary",
-                                        disabled=True
-                                    ),
-                                ],
-                                className="d-grid gap-2",
+                        ]
+                    ),
+                ],
+                style={"border": "1px solid #ccc", "padding": "10px", "marginBottom": "20px"},
+            ),
+
+            # Card 5: Final Run Analysis button
+            dbc.Card(
+                [
+                    dbc.CardHeader("Run Analysis"),
+                    dbc.CardBody(
+                        [
+                            dcc.Markdown(
+                                """
+                                Once everything is configured, click **Run Analysis** 
+                                to perform LDA on your spectra. Depending on the dataset 
+                                size and iterations, this can take a while.
+                                """
+                            ),
+                            dbc.Button(
+                                "Run Analysis",
+                                id="run-button",
+                                color="primary",
                             ),
                             html.Div(id="run-status", style={"marginTop": "20px"}),
-                        ],
-                        width=6,
-                    )
+                        ]
+                    ),
                 ],
-                justify="center",
-            )
+                style={"border": "1px solid #ccc", "padding": "10px", "marginBottom": "20px"},
+            ),
         ],
         style={"display": "block"},
     )

--- a/App/layout.py
+++ b/App/layout.py
@@ -825,7 +825,6 @@ def create_run_analysis_tab():
                 style={"border": "1px solid #ccc", "padding": "10px", "marginBottom": "20px"},
             ),
 
-            # Card 5: Final Run Analysis button
             dbc.Card(
                 [
                     dbc.CardHeader("Run Analysis"),
@@ -835,15 +834,22 @@ def create_run_analysis_tab():
                                 """
                                 Once everything is configured, click **Run Analysis** 
                                 to perform LDA on your spectra. Depending on the dataset 
-                                size and iterations, this can take a while.
+                                size and iterations, this can take a while. Please wait until the 
+                                progress indicator has finished to retrieve the results.
                                 """
                             ),
-                            dbc.Button(
-                                "Run Analysis",
-                                id="run-button",
-                                color="primary",
+                            dcc.Loading(
+                                id="run-analysis-spinner",
+                                type="circle",
+                                children=[
+                                    dbc.Button(
+                                        "Run Analysis",
+                                        id="run-button",
+                                        color="primary",
+                                    ),
+                                    html.Div(id="run-status", style={"marginTop": "20px"})
+                                ]
                             ),
-                            html.Div(id="run-status", style={"marginTop": "20px"}),
                         ]
                     ),
                 ],

--- a/App/layout.py
+++ b/App/layout.py
@@ -60,7 +60,7 @@ def create_run_analysis_tab():
                                     dbc.Input(
                                         id="n-motifs",
                                         type="number",
-                                        value=50,
+                                        value=200,
                                         min=1,
                                     ),
                                 ],
@@ -153,7 +153,7 @@ def create_run_analysis_tab():
                             dbc.InputGroup(
                                 [
                                     dbc.InputGroupText("Iterations", id="iterations-tooltip"),
-                                    dbc.Input(id="n-iterations", type="number", value=1000),
+                                    dbc.Input(id="n-iterations", type="number", value=10000),
                                 ],
                                 className="mb-3",
                                 id="iterations-inputgroup",
@@ -482,7 +482,7 @@ def create_run_analysis_tab():
                                                                     {"label": "best", "value": "best"},
                                                                     {"label": "biggest", "value": "biggest"},
                                                                 ],
-                                                                value="best",
+                                                                value="biggest",
                                                             ),
                                                         ],
                                                         className="mb-2",
@@ -642,7 +642,7 @@ def create_run_analysis_tab():
                                                             dbc.Input(
                                                                 id="train-parallel",
                                                                 type="number",
-                                                                value=1,
+                                                                value=3,
                                                             ),
                                                         ],
                                                         className="mb-2",
@@ -766,7 +766,7 @@ def create_run_analysis_tab():
                                                                     {"label": "pubchem", "value": "pubchem"},
                                                                     {"label": "ecfp", "value": "ecfp"},
                                                                 ],
-                                                                value="rdkit",
+                                                                value="maccs",
                                                             ),
                                                         ],
                                                         className="mb-2",

--- a/MS2LDA/run.py
+++ b/MS2LDA/run.py
@@ -1,3 +1,9 @@
+# If running on mac, force single-thread numeric ops to avoid concurrency issues that leads to tomotopy crashing.
+import platform
+import os
+if platform.system() == "Darwin":
+    os.environ["OMP_NUM_THREADS"] = "1"
+
 import MS2LDA
 from MS2LDA.Preprocessing.load_and_clean import load_mgf
 from MS2LDA.Preprocessing.load_and_clean import load_mzml

--- a/MS2LDA/utils.py
+++ b/MS2LDA/utils.py
@@ -118,10 +118,11 @@ def retrieve_spec4doc(doc2spec_map, ms2lda, doc_id):
 
 
 def download_model_and_data(file_urls=[
-    "https://zenodo.org/records/12625409/files/020724_Spec2Vec_pos_CleanedLibraries.model?download=1",
-    "https://zenodo.org/records/12625409/files/020724_Spec2Vec_pos_CleanedLibraries.model.syn1neg.npy?download=1",
-    "https://zenodo.org/records/12625409/files/020724_Spec2Vec_pos_CleanedLibraries.model.wv.vectors.npy?download=1",
-    "https://zenodo.org/records/12625409/files/positive_s2v_library.pkl?download=1",
+    "https://zenodo.org/records/15003249/files/150225_CleanedLibraries_Spec2Vec_pos_embeddings.npy?download=1",
+    "https://zenodo.org/records/15003249/files/150225_Spec2Vec_pos_CleanedLibraries.model?download=1",
+    "https://zenodo.org/records/15003249/files/150225_Spec2Vec_pos_CleanedLibraries.model.syn1neg.npy?download=1",
+    "https://zenodo.org/records/15003249/files/150225_Spec2Vec_pos_CleanedLibraries.model.wv.vectors.npy?download=1",
+    "https://zenodo.org/records/15003249/files/150225_CombLibraries_spectra.db?download=1",
 ], mode="positive"):
     """Downloads the spec2vec model and data to Add_On/Spec2Vec/model_{mode}_mode.
        If a file already exists, it will be skipped.

--- a/MS2LDA/utils.py
+++ b/MS2LDA/utils.py
@@ -126,8 +126,8 @@ def download_model_and_data(file_urls=[
     """Downloads the spec2vec model and the needed datasets for the automated annotation"""
 
     script_directory = os.path.dirname(os.path.abspath(__file__))
-    #relative_directory = f"Add_On/Spec2Vec/model_{mode}_mode"
-    relative_directory = f"Add_On/Spec2Vec/trash_{mode}"
+    relative_directory = f"Add_On/Spec2Vec/model_{mode}_mode"
+    #relative_directory = f"Add_On/Spec2Vec/trash_{mode}"
     save_directory = os.path.join(script_directory, relative_directory)
 
     os.makedirs(save_directory, exist_ok=True)

--- a/MS2LDA/utils.py
+++ b/MS2LDA/utils.py
@@ -13,14 +13,14 @@ from matchms import set_matchms_logger_level; set_matchms_logger_level("ERROR")
 
 def create_spectrum(motif_k_features, k, frag_tag="frag@", loss_tag="loss@", significant_digits=2, charge=1, motifset="unknown"):
     """creates a spectrum from fragments and losses text representations like frag@123.45 or fragment_67.89
-    
+
     ARGS:
         motif_k_features (list): for motif number k all features in a unified representation
         k (int): motif id
         frag_tag (str): unified pre-fragments tag
         loss_tag (str): unified pre-loss tag
         significant_digits (int): number of significant digits that should be used for each fragment and loss
-        
+
     RETURNS:
         spectrum: matchms spectrum object
     """
@@ -65,7 +65,7 @@ def create_spectrum(motif_k_features, k, frag_tag="frag@", loss_tag="loss@", sig
 
 def match_frags_and_losses(motif_spectrum, analog_spectra):
     """matches fragments and losses between analog and motif spectrum and returns them
-    
+
     ARGS:
         motif_spectrum (matchms.spectrum.object): spectrum build from the found motif
         analog_spectra (list): list of matchms.spectrum.objects which normally are identified by Spec2Vec
@@ -73,7 +73,7 @@ def match_frags_and_losses(motif_spectrum, analog_spectra):
     RETURNS:
         matching_frags (list): a list of sets with fragments that are present in analog spectra and the motif spectra: each set represents one analog spectrum
         matching_losses (list) a list of sets with losses that are present in analog spectra and the motif spectra: each set represents one analog spectrum
-        
+
     """
 
     motif_frags = set(motif_spectrum.peaks.mz)
@@ -122,8 +122,10 @@ def download_model_and_data(file_urls=[
     "https://zenodo.org/records/12625409/files/020724_Spec2Vec_pos_CleanedLibraries.model.syn1neg.npy?download=1",
     "https://zenodo.org/records/12625409/files/020724_Spec2Vec_pos_CleanedLibraries.model.wv.vectors.npy?download=1",
     "https://zenodo.org/records/12625409/files/positive_s2v_library.pkl?download=1",
-    ], mode="positive"):
-    """Downloads the spec2vec model and the needed datasets for the automated annotation"""
+], mode="positive"):
+    """Downloads the spec2vec model and data to Add_On/Spec2Vec/model_{mode}_mode.
+       If a file already exists, it will be skipped.
+    """
 
     script_directory = os.path.dirname(os.path.abspath(__file__))
     relative_directory = f"Add_On/Spec2Vec/model_{mode}_mode"
@@ -131,19 +133,29 @@ def download_model_and_data(file_urls=[
     save_directory = os.path.join(script_directory, relative_directory)
 
     os.makedirs(save_directory, exist_ok=True)
-    print(save_directory)
+    download_count = 0
+    skip_count = 0
 
     for url in file_urls:
+        file_name = os.path.basename(url.split("?download")[0])
+        file_path = os.path.join(save_directory, file_name)
+
+        # Skip if file is present
+        if os.path.exists(file_path):
+            skip_count += 1
+            print(f"File {file_name} already exists, skipping download.")
+            continue
+
+        print(f"Downloading {file_name} ...")
         response = requests.get(url)
         if response.status_code == 200:
-        
-            file_name = os.path.basename(url.split("?download")[0])
-            file_path = os.path.join(save_directory, file_name)
-
             with open(file_path, 'wb') as file:
                 file.write(response.content)
-            print(f"Downloaded {file_name}")
+            download_count += 1
+            print(f"Downloaded {file_name} successfully.")
         else:
-            print(f"Failed to download {url}")
+            raise Exception(f"HTTP Error {response.status_code} while fetching {url}")
 
-            
+    return f"Done. Downloaded {download_count} files, skipped {skip_count} existing."
+
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ conda activate MS2LDA_v2
 
 ### Step 4: Download models and datasets
 
-Download all required models and datasets from [Zenodo](https://zenodo.org/records/12625409).
+Download all required models and datasets from [Zenodo](https://zenodo.org/records/15003249).
 
 ## Running the Dash Application
 


### PR DESCRIPTION
**Changes in this PR:**

1. Uploaded the latest files to zenodo as v4: https://zenodo.org/records/15003249. Updated readme to this too. Once the paper is submitted for real, it might be better to start a new zenodo repo since all the different versions can be confusing.

2. Tidied up layout on the first tab of the dash app, now it looks neater with cards and sections.

3. Added a button to download spec2vec files from zenodo.

> <img width="1313" alt="image" src="https://github.com/user-attachments/assets/e6a66185-0dcb-4087-a1c7-cff80f686728" />

4. Added a progress spinner when we run ms2lda from the app, so at least user knows it doesn't hang. Will switch this to a [progress bar](https://dash.plotly.com/long-callbacks) later.

> <img width="1271" alt="image" src="https://github.com/user-attachments/assets/77cbeae3-6182-4b4a-8c1e-a2a034c5acb1" />

5. Fixed a problem where tomotopy kept crashing on mac os. It used to work for me before, so I'm not sure why I was getting these errors:

> resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown
Process finished with exit code 245

or

> Process finished with exit code 139 (interrupted by signal 11:SIGSEGV) 

Maybe some mac updates that were pushed to my computer recently? In any case, a workaround is to force all internal numeric libraries (BLAS/OpenMP) to use one thread only per process. That avoids concurrency conflicts on macOS, eliminating the segfault. I added this at the top of `run.py`:

```
import platform
import os
if platform.system() == "Darwin":
    os.environ["OMP_NUM_THREADS"] = "1"
```