### PR TITLE
Dash table fixes

### DIFF
--- a/App/callbacks.py
+++ b/App/callbacks.py
@@ -1473,6 +1473,7 @@ def handle_massql_query(run_clicks, reset_clicks, query, motifs_data):
     Input("overlap-thresh", "value"),
     Input("tabs", "value"),
     Input("motif-ranking-massql-matches", "data"),
+    Input("motif-rankings-table", "sort_by"),
     State("screening-fullresults-store", "data"),
     State("optimized-motifs-store", "data"),
 )
@@ -1482,6 +1483,7 @@ def update_motif_rankings_table(
     overlap_thresh,
     active_tab,
     massql_matches,
+    sort_by,
     screening_data,
     optimized_motifs_data,
 ):
@@ -1585,6 +1587,23 @@ def update_motif_rankings_table(
     else:
         screening_hits = ["" for _ in range(len(df))]
     df["Matching Hits"] = screening_hits
+
+    if sort_by and len(sort_by):
+        col_id = sort_by[0]['column_id']
+        direction = sort_by[0]['direction']
+        ascending = (direction == 'asc')
+
+        if col_id == 'Motif':
+            # Implement natural sorting for the 'Motif' column
+            # 1. Extract the number from the 'motif_XXX' string
+            # 2. Convert it to an integer so it sorts numerically
+            # 3. Sort by this new numeric key
+            # 4. Drop the temporary key column
+            df['_sort_key'] = df['Motif'].str.extract(r'(\d+)').astype(int)
+            df = df.sort_values('_sort_key', ascending=ascending).drop(columns=['_sort_key'])
+        else:
+            # For all other columns, use standard pandas sorting
+            df = df.sort_values(col_id, ascending=ascending)
 
     table_data = df.to_dict("records")
     table_columns = [

--- a/App/layout.py
+++ b/App/layout.py
@@ -1557,7 +1557,6 @@ def create_motif_rankings_tab():
                                         data=[],
                                         columns=[],
                                         sort_action="custom",
-                                        filter_action="native",
                                         page_size=20,
                                         style_table={"overflowX": "auto"},
                                         style_cell={

--- a/App/layout.py
+++ b/App/layout.py
@@ -1573,6 +1573,11 @@ def create_motif_rankings_tab():
                                                 "textDecoration": "underline",
                                                 "color": "blue",
                                             },
+                                            {
+                                                'if': {'state': 'active'},
+                                                'backgroundColor': 'transparent',
+                                                'border': 'transparent'
+                                            }
                                         ],
                                         style_header={
                                             "backgroundColor": "rgb(230, 230, 230)",
@@ -2158,6 +2163,11 @@ def create_screening_tab():
                                         "textDecoration": "underline",
                                         "color": "blue",
                                     },
+                                    {
+                                        'if': {'state': 'active'},
+                                        'backgroundColor': 'transparent',
+                                        'border': 'transparent'
+                                    }
                                 ],
                             ),
                             html.Div(
@@ -2393,6 +2403,11 @@ def create_spectra_search_tab():
                                         "textDecoration": "underline",
                                         "color": "blue",
                                     },
+                                    {
+                                        'if': {'state': 'active'},
+                                        'backgroundColor': 'transparent',
+                                        'border': 'transparent'
+                                    }
                                 ],
                                 style_header={
                                     "backgroundColor": "rgb(230, 230, 230)",

--- a/App/layout.py
+++ b/App/layout.py
@@ -1556,7 +1556,7 @@ def create_motif_rankings_tab():
                                         id="motif-rankings-table",
                                         data=[],
                                         columns=[],
-                                        sort_action="native",
+                                        sort_action="custom",
                                         filter_action="native",
                                         page_size=20,
                                         style_table={"overflowX": "auto"},

--- a/App/layout.py
+++ b/App/layout.py
@@ -2381,6 +2381,8 @@ def create_spectra_search_tab():
                                     {"name": "Fragments", "id": "fragments"},
                                     {"name": "Losses", "id": "losses"},
                                 ],
+                                sort_action="custom",
+                                sort_mode="single",
                                 page_size=20,
                                 style_table={"overflowX": "auto"},
                                 style_cell={"textAlign": "left", "whiteSpace": "normal"},


### PR DESCRIPTION
- Make sure spectral search and screening result tables use derived viewport. This prevents clicking the 1st entry on the page 2 of the table, and going to the 1st entry on page 1.
- Removed filtering functionality from the tables itself, as now we have controls to filter the tables.
- Correct sorting (natural order) for motif id and spectral id columns.